### PR TITLE
Add Xcode 9.2 and 9.3b4 UUIDs

### DIFF
--- a/RedXcode/RedXcode-Info.plist
+++ b/RedXcode/RedXcode-Info.plist
@@ -46,6 +46,8 @@
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
+		<string>B395D63E-9166-4CD6-9287-6889D507AD6A</string>
+		<string>8CC8AD71-C38D-4C1A-A34B-DC78BCE76F57</string>
 	</array>
 	<key>XCGCReady</key>
 	<true/>


### PR DESCRIPTION
I've tested both of these and RedXcode still works